### PR TITLE
fix: prod env tweaks (#31)

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -12,7 +12,7 @@ env:
   REGION: asia-east1
   SONAR_PROJECT_KEY: vincejv_fpi-sms-api
   SERVICE_CPU: 1000m
-  SERVICE_MEMORY: 768Mi
+  SERVICE_MEMORY: 512Mi
   SERVICE_ENV: dev
 
 jobs:

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Bump version and push tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.0
+        uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -75,7 +75,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.14
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.14
 
 ENV LANGUAGE='en_US:en'
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
       <dependency>
         <groupId>com.abavilla</groupId>
         <artifactId>fpi-login-api-lib</artifactId>
-        <version>1.0.27</version>
+        <version>1.0.28</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
* fix(config): consistency across all services, bump tagging workflow
* 512mi ram across all dev services
* bump tagging workflow to v6.1
* Dockerfile use Java 17 JRE runtime image in dev
* fpi fw version consistency
* fix(login-api): bump to 1.0.28